### PR TITLE
fix. Default string values now with "quotes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">OpenAPI Generator</h1>
-
+ 
 
 <div align="center">
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GdscriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GdscriptClientCodegen.java
@@ -1,6 +1,7 @@
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import org.openapitools.codegen.*;
 
 import java.io.File;
@@ -342,6 +343,9 @@ public class GdscriptClientCodegen extends DefaultCodegen implements CodegenConf
     @Override
     public String toDefaultValue(Schema schema) {
         if (schema.getDefault() != null) {
+            if (schema instanceof StringSchema) {
+                return "\"" + schema.getDefault().toString() + "\"" ;
+            }
             return schema.getDefault().toString();
         }
 

--- a/modules/openapi-generator/src/main/resources/gdscript/ApiBee.handlebars
+++ b/modules/openapi-generator/src/main/resources/gdscript/ApiBee.handlebars
@@ -84,8 +84,7 @@ func bee_connect_client_if_needed(
 		on_success.call()
 
 	var connecting := self.bee_client.connect_to_host(
-		self.bee_config.host, self.bee_config.port,
-		self.bee_config.ssl_enabled, self.bee_config.verify_host
+		self.bee_config.host, self.bee_config.port
 	)
 	if connecting != OK:
 		var error := {{>partials/api_error_class_name}}.new()

--- a/modules/openapi-generator/src/main/resources/gdscript/api.handlebars
+++ b/modules/openapi-generator/src/main/resources/gdscript/api.handlebars
@@ -28,7 +28,7 @@ func {{operationIdSnakeCase}}(
 	{{#each allParams}}
 	# {{paramName}}{{#if dataType}}: {{dataType}}{{/if}}{{#if defaultValue}} = {{{defaultValue}}}{{/if}}{{#if example}}   Eg: {{{example}}}{{/if}}
 	# {{{description}}}
-	{{paramName}}{{#if required}}{{#if dataType}}: {{{dataType}}}{{/if}}{{/if}}{{#unless required}} = {{#if defaultValue}}{{defaultValue}}{{/if}}{{#unless defaultValue}}null{{/unless}}{{/unless}},
+	{{paramName}}{{#if required}}{{#if dataType}}: {{{dataType}}}{{/if}}{{/if}}{{#unless required}} = {{#if defaultValue}}{{{defaultValue}}}{{/if}}{{#unless defaultValue}}null{{/unless}}{{/unless}},
 	{{/each}}
 	on_success: Callable = Callable(),  # func(result{{#if returnType}}: {{returnType}}{{/if}})
 	on_failure: Callable = Callable(),  # func(error: {{>partials/api_error_class_name}})


### PR DESCRIPTION
I've added quotes for a default value code. I'm not sure I'm doing this properly but it works for me.

Original problem:
![Screenshot 2023-03-09 104838](https://user-images.githubusercontent.com/92994332/223989599-8a8a8fa4-12a6-44f7-a0c1-fe8fa6acc3c3.png)

So I added a quotes to `toDefaultValue` and use `{{{` 3 curly braces so it's not escaped like here:
![Screenshot 2023-03-09 105638](https://user-images.githubusercontent.com/92994332/223990100-c93ec5f6-4f88-41ac-8507-e6bf919a6776.png)

My schema:
```json
{
 "openapi": "3.0.3",
 "info": {
  "title": "Basic Example",
  "description": "This app showcases a trivial REST API.",
  "version": "v1.2.3"
 },
 "paths": {
  "/hello/{name}": {
   "get": {
    "tags": [
     "Communication"
    ],
    "summary": "Greeter",
    "description": "Greeter greets you.",
    "operationId": "Greeter",
    "parameters": [
     {
      "name": "age",
      "in": "query",
      "schema": {
       "type": "integer",
       "default": 5
      }
     },
     {
      "name": "locale",
      "in": "query",
      "schema": {
       "pattern": "^[a-z]{2}-[A-Z]{2}$",
       "enum": [
        "ru-RU",
        "en-US"
       ],
       "type": "string",
       "default": "en-US"
      }
     },
     {
      "name": "name",
      "in": "path",
      "required": true,
      "schema": {
       "minLength": 3,
       "type": "string"
      }
     }
    ],
    "responses": {
     "200": {
      "description": "OK",
      "headers": {
       "X-Now": {
        "style": "simple",
        "schema": {
         "type": "string",
         "format": "date-time"
        }
       }
      },
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/HelloOutput"
        }
       }
      }
     },
     "400": {
      "description": "Bad Request",
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/RestErrResponse"
        }
       }
      }
     }
    }
   }
  }
 },
 "components": {
  "schemas": {
   "HelloOutput": {
    "type": "object",
    "properties": {
     "message": {
      "type": "string"
     }
    }
   },
   "RestErrResponse": {
    "type": "object",
    "properties": {
     "code": {
      "type": "integer",
      "description": "Application-specific error code."
     },
     "context": {
      "type": "object",
      "additionalProperties": {},
      "description": "Application context."
     },
     "error": {
      "type": "string",
      "description": "Error message."
     },
     "status": {
      "type": "string",
      "description": "Status text."
     }
    }
   }
  }
 }
}
```